### PR TITLE
Add prometheus metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,17 @@ ENV CRAWL_GIT_REPO=https://github.com/skylenet/discv4-dns-lists.git \
     CRAWL_DNS_PUBLISH_CLOUDFLARE=false \
     CLOUDFLARE_API_TOKEN="" \
     CLOUDFLARE_ZONE_ID="" \
-    CRAWL_PUBLISH_METRICS=false \
+    INFLUXDB_METRICS_ENABLED=false \
     INFLUXDB_URL=http://localhost:8086 \
     INFLUXDB_DB=metrics \
     INFLUXDB_USER=user \
-    INFLUXDB_PASSWORD=password
+    INFLUXDB_PASSWORD=password \
+    PROMETHEUS_METRICS_ENABLED=true \
+    PROMETHEUS_METRICS_LISTEN=0.0.0.0:9100
 
 RUN apt-get update && apt-get install -y --no-install-recommends git curl jq
 
+EXPOSE 9100
 WORKDIR /crawler
 ADD run.sh .
 CMD ["./run.sh"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # discv4-crawl
 
-⚠️ **Update:** New contributions should go to the active [ethereum/discv4-crawl](https://github.com/ethereum/discv4-crawl) fork.
-
 ## Background
 
 [Geth](https://github.com/ethereum/go-ethereum) now ships with an implementation of [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459). This EIP defines a way to put devp2p node lists behind a DNS name. There are a couple of things worth knowing about this system:

--- a/README.md
+++ b/README.md
@@ -43,16 +43,18 @@ Name | Default | Description
 `CRAWL_DNS_PUBLISH_CLOUDFLARE` | `false` | Publish the TXT records to a DNS zone on Cloudflare
 `CLOUDFLARE_API_TOKEN`| `` | API token used for the Cloudflare API
 `CLOUDFLARE_ZONE_ID` | `` | Cloudflare DNS zone identifier. This is the zone where the records will be published to.
-`CRAWL_PUBLISH_METRICS` | `false` | Set to `true` if you want to send metrics to InfluxDB
+`INFLUXDB_METRICS_ENABLED` | `false` | Set to `true` if you want to send metrics to InfluxDB
 `INFLUXDB_URL` | `http://localhost:8086` | Address of the InfluxDB API
 `INFLUXDB_DB` | `metrics` | Database name
 `INFLUXDB_USER` | `user` | Username for InfluxDB
 `INFLUXDB_PASSWORD` | `password` | Password for InfluxDB
+`PROMETHEUS_METRICS_ENABLED`| `true` | Enable prometheus metrics endpoint
+`PROMETHEUS_METRICS_LISTEN` | `0.0.0.0:9100` | Server listening
 
 ### Building the image
 
 ```sh
-$ docker build -t disc4-crawl .
+$ docker build -t discv4-crawl .
 ```
 
 ### Run examples

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # discv4-crawl
 
+⚠️ **Update:** New contributions should go to the active [ethereum/discv4-crawl](https://github.com/ethereum/discv4-crawl) fork.
+
 ## Background
 
 [Geth](https://github.com/ethereum/go-ethereum) now ships with an implementation of [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459). This EIP defines a way to put devp2p node lists behind a DNS name. There are a couple of things worth knowing about this system:


### PR DESCRIPTION
Adding web server to serve `/metrics` endpoint that can be scraped by prometheus. 

Just and example on how it looks like:

```
$  docker exec -it dns curl localhost:9100/metrics
devp2p_discv4_dns_nodes{domain="all.goerli.nodes.ethflare.xyz"} 242
devp2p_discv4_dns_nodes{domain="all.mainnet.nodes.ethflare.xyz"} 1127
devp2p_discv4_dns_nodes{domain="all.rinkeby.nodes.ethflare.xyz"} 116
devp2p_discv4_dns_nodes{domain="all.ropsten.nodes.ethflare.xyz"} 185
devp2p_discv4_dns_nodes{domain="les.goerli.nodes.ethflare.xyz"} 7
devp2p_discv4_dns_nodes{domain="les.mainnet.nodes.ethflare.xyz"} 62
devp2p_discv4_dns_nodes{domain="les.rinkeby.nodes.ethflare.xyz"} 10
devp2p_discv4_dns_nodes{domain="les.ropsten.nodes.ethflare.xyz"} 5
```

There's a small breaking change by renaming `CRAWL_PUBLISH_METRICS` to `INFLUXDB_METRICS_ENABLED`. This should be updated on any deployment that wants to keep pushing metrics to influx directly.