### PR TITLE
feat: add hoodi testnet

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -79,6 +79,10 @@ generate_list() {
   # Holesky
   filter_list holesky all   -limit 250 || return 1
   filter_list holesky snap  -limit 25   -snap || return 1
+
+  # Hoodi
+  filter_list hoodi all   -limit 500 || return 1
+  filter_list hoodi snap  -limit 100   -snap || return 1
 }
 
 sign_lists() {


### PR DESCRIPTION
Depends on go-ethereum to support:  `devp2p nodeset filter all.json -eth-network hoodi ...`